### PR TITLE
Fix for pg10 partition pruning

### DIFF
--- a/include/hypopg_table.h
+++ b/include/hypopg_table.h
@@ -92,6 +92,10 @@ bool hypo_table_remove(Oid tableid, hypoTable *parent, bool deep);
 void hypo_injectHypotheticalPartitioning(PlannerInfo *root,
 					 Oid relationObjectId,
 					 RelOptInfo *rel);
+#if PG_VERSION_NUM < 110000
+void hypo_markDummyIfExcluded(PlannerInfo *root, RelOptInfo *rel,
+							  Index rti, RangeTblEntry *rte);
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
I added PartitionedChildRelInfo which is used for pg10.  Also, I used set_rel_pathlist_hook again so that we can set dummyrel for partition pruning. 