### PR TITLE
Unconditionally setting CLIENT_ENCODING to UTF-8 will break pg_restor…

### DIFF
--- a/hypopg--1.1.2.sql
+++ b/hypopg--1.1.2.sql
@@ -6,6 +6,8 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION hypopg" to load this file. \quit
 
+SET LOCAL client_encoding = 'UTF8';
+
 CREATE FUNCTION hypopg_reset()
     RETURNS void
     LANGUAGE C VOLATILE COST 100

--- a/hypopg--1.1.2.sql
+++ b/hypopg--1.1.2.sql
@@ -6,8 +6,6 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION hypopg" to load this file. \quit
 
-SET client_encoding = 'UTF8';
-
 CREATE FUNCTION hypopg_reset()
     RETURNS void
     LANGUAGE C VOLATILE COST 100

--- a/hypopg--2.0.0beta.sql
+++ b/hypopg--2.0.0beta.sql
@@ -6,8 +6,6 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION hypopg" to load this file. \quit
 
-SET client_encoding = 'UTF8';
-
 -- General functions
 --
 

--- a/hypopg--2.0.0beta.sql
+++ b/hypopg--2.0.0beta.sql
@@ -6,6 +6,8 @@
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION hypopg" to load this file. \quit
 
+SET LOCAL client_encoding = 'UTF8';
+
 -- General functions
 --
 


### PR DESCRIPTION
Unconditionally setting CLIENT_ENCODING to UTF-8 will break pg_restore for non UTF-8 databases.

Corresponding test-case attached: [pg_restore_latin1_test.zip](https://github.com/HypoPG/hypopg/files/3097859/pg_restore_latin1_test.zip)

Is hard-coded client_encoding really needed?