### PR TITLE
Fix typos in hypothetical_objects.rst

### DIFF
--- a/docs/hypothetical_objects.rst
+++ b/docs/hypothetical_objects.rst
@@ -3,26 +3,26 @@
 Hypothetical objects
 ====================
 
-HypoPG support two kinds of hypothetical objects: hypothetical indexes and
-hypothetical partitioning.
+HypoPG support two kinds of hypothetical objects: *hypothetical indexes* and
+*hypothetical partitioning*.
 
 .. _hypothetical_indexes:
 
-Hypothetical indexes
+Hypothetical Indexes
 --------------------
-A hypothetical, or virtual, index is an index that doesn't really exists, and
-thus doesn't cost CPU, disk or any resource to create.  They're useful to know
-if specific indexes can increase performance for problematic queries, since
-you can know if PostgreSQL will use these indexes or not without having to
+A hypothetical, or virtual, index is an index that does not really exist, and
+therefore does not cost CPU, disk or any resource to create. They are useful to find out
+whether specific indexes can increase the performance for problematic queries, since
+you can discover if PostgreSQL will use these indexes or not without having to
 spend resources to create them.
 
 .. _hypothetical_partitioning:
 
-Hypothetical partitioning
+Hypothetical Partitioning
 -------------------------
 Hypothetical partitioning, available for PostgreSQL servers version 10 and
-above, is a real table on which you can hypothetically apply partitining
-scheme as you would do for declarative partitioning.  PostgreSQL will act as if
-this table was really partitioned, so you can know quickly test multiple
-partitioning scheme, and you can see how each of them will change your queries
-behavior and check which one is the best for your specific appliation.
+later, is a real table to which you can hypothetically apply partitining
+schemes as you would do for declarative partitioning. PostgreSQL will act as if
+this table was really partitioned, so you can quickly test multiple
+partitioning schemes, and you can see how each will change your query's
+behavior and check which one is the best for your specific application.


### PR DESCRIPTION
This is text available on https://hypopg.readthedocs.io/en/latest/hypothetical_objects.html

I have removed some typos and tried to (very slighty) improve the wording