### PR TITLE
Correct spelling in test script

### DIFF
--- a/test/sql/hypo_index_part.sql
+++ b/test/sql/hypo_index_part.sql
@@ -1,4 +1,4 @@
--- Hypothetical on partitioned tabled
+-- Hypothetical on partitioned tables
 
 CREATE TABLE hypo_part(id1 integer, id2 integer, id3 integer)
     PARTITION BY LIST (id1);

--- a/test/sql/hypo_index_part_10.sql
+++ b/test/sql/hypo_index_part_10.sql
@@ -1,4 +1,4 @@
--- Hypothetical on partitioned tabled
+-- Hypothetical on partitioned tables
 
 CREATE TABLE hypo_part(id1 integer, id2 integer, id3 integer)
     PARTITION BY LIST (id1);


### PR DESCRIPTION
The word `tabled` in test scripts was misspelled.

This PR corrects the spelling.