### PR TITLE
Correctly allocate hypoIndex entries

### DIFF
--- a/hypopg_index.c
+++ b/hypopg_index.c
@@ -206,9 +206,9 @@ hypo_newIndex(Oid relid, char *accessMethod, int nkeycolumns, int ninccolumns,
 	if ((entry->relam == BTREE_AM_OID) || (entry->amcanorder))
 	{
 		if (entry->relam != BTREE_AM_OID)
-			entry->sortopfamily = palloc0(sizeof(Oid) * nkeycolumns);
-		entry->reverse_sort = palloc0(sizeof(bool) * nkeycolumns);
-		entry->nulls_first = palloc0(sizeof(bool) * nkeycolumns);
+			entry->sortopfamily = palloc0(sizeof(Oid) * (nkeycolumns + ninccolumns));
+		entry->reverse_sort = palloc0(sizeof(bool) * (nkeycolumns + ninccolumns));
+		entry->nulls_first = palloc0(sizeof(bool) * (nkeycolumns + ninccolumns));
 	}
 	else
 	{


### PR DESCRIPTION
`ncolumns` field is calculated as:
```
      entry->ncolumns = nkeycolumns + ninccolumns;
```
In `hypo_injectHypotheticalIndex`:
```
			for (i = 0; i < ncolumns; i++)
			{
				index->sortopfamily[i] = entry->sortopfamily[i];
				index->reverse_sort[i] = entry->reverse_sort[i];
				index->nulls_first[i] = entry->nulls_first[i];
```
However, when these fields are initialized, only `nkeycolumns` elements are allocated.

This PR changes the element count in allocations so that enough memory is allocated.